### PR TITLE
Improve run for SPM projects

### DIFF
--- a/Plugins/BuildSystem/Sources/SPMBuildSystem.swift
+++ b/Plugins/BuildSystem/Sources/SPMBuildSystem.swift
@@ -92,7 +92,8 @@ class SPMLauncher: Launcher {
     programProc.currentDirectoryURL = packageUrl.deletingLastPathComponent()
     programProc.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
     programProc.environment = ["PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"]
-    programProc.arguments = ["run"]
+    //we skip build because we always build before run
+    programProc.arguments = ["run", "--skip-build"]
     
     var programProcConsole: Console?
     programProc.terminationHandler = { process in


### PR DESCRIPTION
The command `swift run` makes build and we building the same project twice every run. So we can just skip `swift run`'s build because Nimble makes build before each run.

This PR contains a solution for `NM-198 Running Vapor causes compilation of files that have already been compiled`