### PR TITLE
Error message shouldn't overlap code

### DIFF
--- a/Plugins/CodeEditor/CodeEditor/Sources/DiagnosticView.swift
+++ b/Plugins/CodeEditor/CodeEditor/Sources/DiagnosticView.swift
@@ -97,7 +97,7 @@ class DiagnosticView: NSStackView {
   }
   
   private func setupView() {
-    guard let textView = textView, let textStorage = textView.textStorage else {
+    guard let textView = textView as? CodeEditorTextView, let textStorage = textView.textStorage else {
       return
     }
     textView.addSubview(self)
@@ -106,7 +106,7 @@ class DiagnosticView: NSStackView {
     let lineRange: Range<Int> = textStorage.string.lineRange(line: line - 1)
     let string = String(textStorage.string[lineRange])
     self.translatesAutoresizingMaskIntoConstraints = false
-    self.widthAnchor.constraint(equalToConstant: textView.bounds.width - textView.stringWidth(for: string)!).isActive = true
+    self.widthAnchor.constraint(lessThanOrEqualToConstant: textView.bounds.width - (textView.stringWidth(for: string) ?? 0) - (textView.lineNumberView?.bounds.width ?? 0)).isActive = true
     self.trailingAnchor.constraint(equalTo: textView.trailingAnchor, constant: -10).isActive = true
     self.topAnchor.constraint(equalTo: textView.topAnchor, constant: lineHeight * CGFloat(line - 1)).isActive = true
   }


### PR DESCRIPTION
Before:
<img width="885" alt="Screenshot 2020-04-22 at 19 06 00" src="https://user-images.githubusercontent.com/15704847/79980698-b64ec880-84cd-11ea-971d-6bc41cc2e216.png">

After:
<img width="895" alt="Screenshot 2020-04-22 at 19 03 03" src="https://user-images.githubusercontent.com/15704847/79980718-be0e6d00-84cd-11ea-8174-9013e5b10533.png">
