### PR TITLE
[NM-297] Nimble crashes during open second window

### DIFF
--- a/Nimble/Sources/Extensions/Command+Toolbar.swift
+++ b/Nimble/Sources/Extensions/Command+Toolbar.swift
@@ -28,8 +28,8 @@ extension Command {
   }
   
   var view: NSView {
-    guard self.toolbarView == nil else {
-      return self.toolbarView!
+    guard self.toolbarViewClass == nil else {
+      return self.toolbarViewClass!.loadFromNib()
     }
     
     let button = NSButton()

--- a/Nimble/Sources/NimbleWorkbench.swift
+++ b/Nimble/Sources/NimbleWorkbench.swift
@@ -347,7 +347,7 @@ extension NimbleWorkbench: NSToolbarDelegate {
 
   public func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
       var ids: [NSToolbarItem.Identifier] = CommandManager.shared.commands.compactMap {
-        guard $0.group == nil && ($0.toolbarIcon != nil || $0.toolbarView != nil) else { return nil }
+        guard $0.group == nil && ($0.toolbarIcon != nil || $0.toolbarViewClass != nil) else { return nil }
         return $0.toolbarItemIdentifier
       }
     

--- a/Packages/NimbleCore/Sources/NimbleCore/Command.swift
+++ b/Packages/NimbleCore/Sources/NimbleCore/Command.swift
@@ -32,7 +32,7 @@ open class Command {
   
   // Toolbar item
   public let toolbarIcon: NSImage?
-  public let toolbarView: NSView?
+  public let toolbarViewClass: NSView.Type?
 
   // Actions
   private let handler: Handler
@@ -59,21 +59,21 @@ open class Command {
     self.menuPath = menuPath
     self.keyEquivalent = keyEquivalent
     self.toolbarIcon = toolbarIcon
-    self.toolbarView = nil
+    self.toolbarViewClass = nil
     self.handler = handler
   }
   
   public init(name: String,
               menuPath: String? = nil,
               keyEquivalent: String? = nil ,
-              view: NSView? = nil,
+              viewClass: NSView.Type? = nil,
               handler: (@escaping Handler) = { _ in return } ) {
 
     self.name = name
     self.menuPath = menuPath
     self.keyEquivalent = keyEquivalent
     self.toolbarIcon = nil
-    self.toolbarView = view
+    self.toolbarViewClass = viewClass
     self.handler = handler
   }
 }

--- a/Plugins/BuildSystem/Sources/Commands.swift
+++ b/Plugins/BuildSystem/Sources/Commands.swift
@@ -92,8 +92,7 @@ final class Clean: BuildSystemCommand {
 
 final class SelectTarget: Command {
   init() {
-    let view = ToolbarTargetControl.loadFromNib()
-    super.init(name: "Select Target", menuPath: nil, keyEquivalent: nil, view: view)
+    super.init(name: "Select Target", menuPath: nil, keyEquivalent: nil, viewClass: ToolbarTargetControl.self)
   }
   
   override func validate(in workbench: Workbench) -> State {

--- a/Plugins/BuildSystem/Sources/UI/ToolbarTargetControl.swift
+++ b/Plugins/BuildSystem/Sources/UI/ToolbarTargetControl.swift
@@ -125,6 +125,10 @@ class ToolbarTargetControl : NSView {
       }
       targets.forEach{addMenuItem(target: $0, to: menu)}
     }
+    
+    guard !menu.items.isEmpty else {
+      return
+    }
     menu.popUp(positioning: menu.item(at: 0), at: NSEvent.mouseLocation, in: nil)
   }
   


### PR DESCRIPTION
Nimble crashes during open second window due to toolbars use the same view of the target control into different windows.