### PR TITLE
[NM-308] Remove SPM swift files from single swift file list in target

### DIFF
--- a/Plugins/BuildSystem/Sources/SPMBuildSystem.swift
+++ b/Plugins/BuildSystem/Sources/SPMBuildSystem.swift
@@ -104,7 +104,7 @@ private extension SPMBuildSystem {
   }
 }
 
-fileprivate class SPMTarget: Target {
+class SPMTarget: Target {
   var name: String {
     folder.name
   }
@@ -232,5 +232,19 @@ extension MacVariant {
     let proc = createProcess(source: source)
     proc.arguments = ["package", "clean"]
     return proc
+  }
+}
+
+
+extension Array where Element == SPMTarget {
+  func containsSwiftFile(document: Document) -> Bool {
+    guard let filePathString = document.fileURL?.file?.path.string else { return false }
+    for target in self {
+      let targetFolder = target.folder
+      if targetFolder.path.string.count < filePathString.count, filePathString.hasPrefix(targetFolder.path.string){
+        return true
+      }      
+    }
+    return false
   }
 }

--- a/Plugins/BuildSystem/Sources/SwiftBuildSystem.swift
+++ b/Plugins/BuildSystem/Sources/SwiftBuildSystem.swift
@@ -18,6 +18,18 @@ class SwiftBuildSystem: BuildSystem {
   
   func targets(in workbench: Workbench) -> [Target] {
     guard let document = workbench.currentDocument, canHandle(document: document) else { return [] }
+    
+    //Workaround to prevent allow compile single swift file in SPM package
+    if BuildSystemsManager.shared.activeBuildSystem is Automatic {
+      if let spmBuildSystem = BuildSystemsManager.shared.buildSystems.first(where: {$0 is SPMBuildSystem}) {
+        let spmTargets = spmBuildSystem.targets(in: workbench).compactMap{$0 as? SPMTarget}
+        guard !spmTargets.isEmpty else { return [] }
+        if spmTargets.containsSwiftFile(document: document) {
+          return []
+        }
+      }
+    }
+    
     let target = SwiftTarget(document: document, workbench: workbench)
     target.variants.append(SingleDocumentVariant(target: target, buildSystem: self))
     return [target]


### PR DESCRIPTION
I check if the current file is part of one of the SPM targets and don't show this file as a single swift target if it is.  