### PR TITLE
[NM-404] Text displaced on the next line when long diagnostic view appeared

### DIFF
--- a/Plugins/CodeEditor/CodeEditor/Sources/DiagnosticView.swift
+++ b/Plugins/CodeEditor/CodeEditor/Sources/DiagnosticView.swift
@@ -99,9 +99,14 @@ class DiagnosticView: NSStackView {
 
     let lineSize =  textView.boundingRect(for: lineRange)?.size ?? NSSize()
     let defaultLineHeight = textView.layoutManager!.lineHeight
-    let topOffset = wrappedLineTopOffset() ?? defaultLineHeight * CGFloat(line - 1)
+    var topOffset = wrappedLineTopOffset() ?? defaultLineHeight * CGFloat(line - 1)
 
-    let leadingOffset = min(0.8 * textView.frame.size.width, lineSize.width)
+    var leadingOffset = min(0.8 * textView.frame.size.width, lineSize.width)
+    
+    if lineRange.location == textStorage.string.offset(at: textStorage.string.endIndex) {
+      topOffset += defaultLineHeight
+      leadingOffset = 0.1 * textView.frame.size.width
+    }
 
     let placeholder = NSRect(x: leadingOffset + 10,
                              y: topOffset,


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/15704847/101135987-37af3180-363f-11eb-8f64-a3e592971b55.png)
After:
![image](https://user-images.githubusercontent.com/15704847/101136015-3f6ed600-363f-11eb-9b89-38388476f8b3.png)
